### PR TITLE
Review improvements

### DIFF
--- a/image_cleanup.py
+++ b/image_cleanup.py
@@ -35,7 +35,7 @@ parser.add_argument(
     "-v",
     "--verbose",
     action="store_true",
-    help="Provide output for AMIs that are being exlcuded",
+    help="Provide output for AMIs that are being excluded",
 )
 
 args = parser.parse_args()
@@ -117,7 +117,7 @@ def handler(config, plan=True, verbose=False):
             (specificly_excluded_ids, "'excluded_ids' defined in the config"),
             (
                 images_in_use,
-                "'images_in_use' - images that associated with an instance",
+                "'images_in_use' - images that are associated with an instance",
             ),
             (
                 newest_images,

--- a/image_cleanup.py
+++ b/image_cleanup.py
@@ -94,7 +94,7 @@ def handler(config, plan=True):
 
     if plan == False:
         print("The following AMIs WILL BE deregistered:")
-        deregister_loop(included_images, set_of_image_ids_to_exclude, !plan)
+        deregister_loop(included_images, set_of_image_ids_to_exclude, not plan)
         second_confirmation = input(
             "Would you like to deregister the above AMIs? ['yes' to confirm]: "
         )

--- a/test_image_cleanup.py
+++ b/test_image_cleanup.py
@@ -99,13 +99,18 @@ def test_parse_tags():
     assert parse_tags([]) == False
     assert parse_tags({}) == False
 
-@patch('builtins.print')
+
+@patch("builtins.print")
 def test_deregister_loop(mocked_print):
-    test_image = ExampleImage(1,"May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543")
-    deregister_loop([test_image], [], True) # "call" once
-    deregister_loop([test_image], [], False) # "call" again
-    deregister_loop([test_image], [1], False) # "call" again, but shouldn't do anything
+    test_image = ExampleImage(
+        1, "May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543"
+    )
+    deregister_loop([test_image], [], True)  # "call" once
+    deregister_loop([test_image], [], False)  # "call" again
+    deregister_loop([test_image], [1], False)  # "call" again, but shouldn't do anything
     assert mocked_print.mock_calls == [
-        call('1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4'), # plan == True
-        call('This is where I would image.deregister() for 1') # plan == False
+        call(
+            "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"
+        ),  # plan == True
+        call("This is where I would image.deregister() for 1"),  # plan == False
     ]

--- a/test_image_cleanup.py
+++ b/test_image_cleanup.py
@@ -7,6 +7,7 @@ from utility_functions import (
     parse_config_file,
     parse_tags,
     deregister_loop,
+    verbose_exclusion_loops,
 )
 
 
@@ -109,8 +110,31 @@ def test_deregister_loop(mocked_print):
     deregister_loop([test_image], [], False)  # "call" again
     deregister_loop([test_image], [1], False)  # "call" again, but shouldn't do anything
     assert mocked_print.mock_calls == [
+        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
+        call("This is where I would image.deregister() for 1"),
+    ]
+
+
+@patch("builtins.print")
+def test_verbose_exclusion_loops(mocked_print):
+    test_image = ExampleImage(
+        1, "May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543"
+    )
+    categories = [
+        ([1], "category one"),
+        ([2, 3, 4], "category two"),
+        ([3, 4, 1], "category three"),
+    ]
+    verbose_exclusion_loops([test_image], categories)
+    assert mocked_print.mock_calls == [
         call(
-            "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"
-        ),  # plan == True
-        call("This is where I would image.deregister() for 1"),  # plan == False
+            "The following images have been excluded from degrestration by the following categories"
+        ),
+        call("Excluded by category one:"),
+        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
+        call("----"),
+        call("----"),
+        call("Excluded by category three:"),
+        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
+        call("----"),
     ]

--- a/test_image_cleanup.py
+++ b/test_image_cleanup.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch, call
+
 from utility_functions import (
     not_int,
     time_to_live,
     latest_images,
     parse_config_file,
     parse_tags,
+    deregister_loop,
 )
 
 
@@ -95,3 +98,14 @@ def test_parse_tags():
     assert parse_tags(bad_tags) == False
     assert parse_tags([]) == False
     assert parse_tags({}) == False
+
+@patch('builtins.print')
+def test_deregister_loop(mocked_print):
+    test_image = ExampleImage(1,"May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543")
+    deregister_loop([test_image], [], True) # "call" once
+    deregister_loop([test_image], [], False) # "call" again
+    deregister_loop([test_image], [1], False) # "call" again, but shouldn't do anything
+    assert mocked_print.mock_calls == [
+        call('1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4'), # plan == True
+        call('This is where I would image.deregister() for 1') # plan == False
+    ]

--- a/utility_functions.py
+++ b/utility_functions.py
@@ -3,7 +3,7 @@ from dateutil import parser
 
 
 def not_int(val):
-    '''Takes a value, returns a bool whether it is an int or not'''
+    """Takes a value, returns a bool whether it is an int or not"""
     try:
         int(val)
     except ValueError:
@@ -12,10 +12,10 @@ def not_int(val):
 
 
 def time_to_live(images, days_to_live):
-    '''
+    """
     Takes in an iterable of images, and an int.
     Returns a list of image ids that have existed fewer days than the int provided.
-    '''
+    """
     return_list = []
     for image in images:
         image_date_created = parser.parse(image.creation_date, ignoretz=True)
@@ -25,12 +25,12 @@ def time_to_live(images, days_to_live):
 
 
 def latest_images(images, iterations_allowed):
-    '''
+    """
     Takes in an iterable of images, and an int.
     Groups images together by some features of image.name.
     Returns a list of image ids that represent the number of iterations allowed less
     than or equal to the int provided, from the groups created, sorted newest to oldest.
-    '''
+    """
     if iterations_allowed == 0:
         return []
 
@@ -62,10 +62,10 @@ def latest_images(images, iterations_allowed):
 
 
 def parse_config_file(config):
-    '''
+    """
     Takes in a dictionary.
     Returns a dictionary of provided, or default values.
-    '''
+    """
     configuration = {}
     try:
         configuration["tags"] = config["tags"]
@@ -88,10 +88,10 @@ def parse_config_file(config):
 
 
 def parse_tags(tags):
-    '''
-    Takes in a dictionary, returns a list of dictionaries of provided data in 
+    """
+    Takes in a dictionary, returns a list of dictionaries of provided data in
     a restructured way.
-    '''
+    """
     try:
         tag_filters = [
             {"Name": f"tag:{tag}", "Values": tags[tag]} for tag in tags.keys()
@@ -108,16 +108,17 @@ def parse_tags(tags):
         print("Tags not formatted correctly in configuration file")
         return False
 
+
 def deregister_loop(included_images, excluded_ids, plan):
-    '''
+    """
     Takes iterable of images to deregister, list of image IDs to exclude from process, and boolean
     of the mode of operation. Returns None. Side effects include printing the images to deregister
     if plan is True, or calling deregister() on the image if plan is False
-    '''
+    """
     for image in included_images:
-            if image.id not in excluded_ids:
-                if plan == True:
-                    print(f"{image.id}  {image.name}  {image.creation_date}")
-                else:
-                    print(f"This is where I would image.deregister() for {image.id}")
+        if image.id not in excluded_ids:
+            if plan == True:
+                print(f"{image.id}  {image.name}  {image.creation_date}")
+            else:
+                print(f"This is where I would image.deregister() for {image.id}")
     return

--- a/utility_functions.py
+++ b/utility_functions.py
@@ -107,3 +107,17 @@ def parse_tags(tags):
     except AttributeError:
         print("Tags not formatted correctly in configuration file")
         return False
+
+def deregister_loop(included_images, excluded_ids, plan):
+    '''
+    Takes iterable of images to deregister, list of image IDs to exclude from process, and boolean
+    of the mode of operation. Returns None. Side effects include printing the images to deregister
+    if plan is True, or calling deregister() on the image if plan is False
+    '''
+    for image in included_images:
+            if image.id not in excluded_ids:
+                if plan == True:
+                    print(f"{image.id}  {image.name}  {image.creation_date}")
+                else:
+                    print(f"This is where I would image.deregister() for {image.id}")
+    return

--- a/utility_functions.py
+++ b/utility_functions.py
@@ -27,7 +27,7 @@ def time_to_live(images, days_to_live):
 
 def latest_images(images, iterations_allowed):
     """
-    Takes in an iterable of images, and an int.
+    Takes an iterable of image objects, and an int.
     Groups images together by some features of image.name.
     Returns a list of image ids that represent the number of iterations allowed less
     than or equal to the int provided, from the groups created, sorted newest to oldest.
@@ -114,4 +114,25 @@ def deregister_loop(included_images, excluded_ids, plan):
                 print(f"{image.id}  {image.name}  {image.creation_date}")
             else:
                 print(f"This is where I would image.deregister() for {image.id}")
+    return
+
+
+def verbose_exclusion_loops(included_images, exclusion_categories):
+    """
+    Takes an iterable of image objects and a list of tuples. The tuples contain the list of
+    IDs to exclude, as well as a message explaining what the list is. Returns None. Side effects
+    include printing image information.
+    """
+    print(
+        "The following images have been excluded from degrestration by the following categories"
+    )
+    for category in exclusion_categories:
+        has_printed = False
+        for image in included_images:
+            if image.id in category[0]:
+                if has_printed == False:
+                    print(f"Excluded by {category[1]}:")
+                    has_printed = True
+                print(f"{image.id}  {image.name}  {image.creation_date}")
+        print("----")
     return


### PR DESCRIPTION
This PR resolves [ATGU-2920](https://jira.huit.harvard.edu/browse/ATGU-2920) by:

- Replacing `quit()` with `sys.exit()`
- Refactoring some repeated code into a `deregister_loop` function
- Refactoring complicated sorting code in `latest_images` to use `collections.deque`
- Adding a `--verbose` flag and a `verbose_exclusion_loops` function to explain why images have been excluded from dereregistration

## Notes
I am not particularly thrilled with the `--verbose` implementation, but it'll work for now.