### PR TITLE
Main improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .pytest_cache
 .tox
 **.egg-info
+.python-version

--- a/image_cleanup.py
+++ b/image_cleanup.py
@@ -86,7 +86,6 @@ def handler(config, plan=True, verbose=False):
         else:
             deregister_loop(included_images, set_of_image_ids_to_exclude, plan)
 
-
     if verbose == True:
         exclusion_categories = [
             (excluded_images_by_tags, "'exclusion_tags' defined in the config"),

--- a/image_cleanup.py
+++ b/image_cleanup.py
@@ -5,17 +5,20 @@ import sys
 import yaml
 
 from utility_functions import (
-    time_to_live,
+    deregister_loop,
     latest_images,
     parse_config_file,
     parse_tags,
-    deregister_loop,
+    time_to_live,
     verbose_exclusion_loops,
 )
 
 
 def handler(config, plan=True, verbose=False):
-
+    """
+    Takes a config dict, plan bool, and verbose bool. Returns int (0,1) to mark pass or error.
+    Side effects include printing image information, getting user input and deregistering images.
+    """
     boto_resource = boto3.resource("ec2")
 
     # parse the config file, so we don't need to check it everywhere
@@ -71,8 +74,7 @@ def handler(config, plan=True, verbose=False):
     if plan == True:
         print("The following AMIs would be deregistered:")
         deregister_loop(included_images, set_of_image_ids_to_exclude, plan)
-
-    if plan == False:
+    else:
         print("The following AMIs WILL BE deregistered:")
         deregister_loop(included_images, set_of_image_ids_to_exclude, not plan)
         second_confirmation = input(
@@ -83,6 +85,7 @@ def handler(config, plan=True, verbose=False):
             return 0
         else:
             deregister_loop(included_images, set_of_image_ids_to_exclude, plan)
+
 
     if verbose == True:
         exclusion_categories = [
@@ -148,7 +151,7 @@ def main(argv=None):
 
     if args.plan:
         print("Running in PLAN mode")
-        handler(config, plan=True, verbose=args.verbose)
+        return handler(config, plan=True, verbose=args.verbose)
     elif not args.execute and not args.plan:
         print("Please, specify if you would like to run --plan or --execute.")
         print("If you are unsure, run in PLAN mode with --plan")

--- a/test_image_cleanup.py
+++ b/test_image_cleanup.py
@@ -15,6 +15,9 @@ class ExampleImage:
         self.creation_date = creation_date
         self.name = name
 
+    def deregister(self):
+        pass
+
 
 test_images = [
     (1, "May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543"),
@@ -109,7 +112,7 @@ def test_deregister_loop(capsys):
     captured = capsys.readouterr()
     expected_prints = [
         "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4",
-        "This is where I would image.deregister() for 1",
+        "deregistering 1",
     ]
     for statement in expected_prints:
         assert statement in captured.out

--- a/test_image_cleanup.py
+++ b/test_image_cleanup.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch, call
-
 from utility_functions import (
     not_int,
     time_to_live,
@@ -101,22 +99,23 @@ def test_parse_tags():
     assert parse_tags({}) == False
 
 
-@patch("builtins.print")
-def test_deregister_loop(mocked_print):
+def test_deregister_loop(capsys):
     test_image = ExampleImage(
         1, "May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543"
     )
     deregister_loop([test_image], [], True)  # "call" once
     deregister_loop([test_image], [], False)  # "call" again
     deregister_loop([test_image], [1], False)  # "call" again, but shouldn't do anything
-    assert mocked_print.mock_calls == [
-        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
-        call("This is where I would image.deregister() for 1"),
+    captured = capsys.readouterr()
+    expected_prints = [
+        "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4",
+        "This is where I would image.deregister() for 1",
     ]
+    for statement in expected_prints:
+        assert statement in captured.out
 
 
-@patch("builtins.print")
-def test_verbose_exclusion_loops(mocked_print):
+def test_verbose_exclusion_loops(capsys):
     test_image = ExampleImage(
         1, "May 1, 2020 at 10:19:24 AM UTC-4", "atg-test1-123423543"
     )
@@ -126,15 +125,13 @@ def test_verbose_exclusion_loops(mocked_print):
         ([3, 4, 1], "category three"),
     ]
     verbose_exclusion_loops([test_image], categories)
-    assert mocked_print.mock_calls == [
-        call(
-            "The following images have been excluded from degrestration by the following categories"
-        ),
-        call("Excluded by category one:"),
-        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
-        call("----"),
-        call("----"),
-        call("Excluded by category three:"),
-        call("1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4"),
-        call("----"),
+    captured = capsys.readouterr()
+    expected_prints = [
+        "The following images have been excluded from degrestration by the following categories",
+        "Excluded by category one:",
+        "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4",
+        "Excluded by category three:",
+        "1  atg-test1-123423543  May 1, 2020 at 10:19:24 AM UTC-4",
     ]
+    for statement in expected_prints:
+        assert statement in captured.out

--- a/utility_functions.py
+++ b/utility_functions.py
@@ -113,7 +113,8 @@ def deregister_loop(included_images, excluded_ids, plan):
             if plan == True:
                 print(f"{image.id}  {image.name}  {image.creation_date}")
             else:
-                print(f"This is where I would image.deregister() for {image.id}")
+                print(f"deregistering {image.id}")
+                image.deregister()
     return
 
 


### PR DESCRIPTION
This PR improves the cli by:

- Moving the main functionality to a `main` function
- Adding a `if __name__ == "__main__"` and calling the main function (this makes the cli importable for testing etc.)
- Passing `argv=None` to `main` and parsing as `parser.parse_args(argv)` so that it can be tested
- Wrapping the call of the `main` function in `sys.exit()` so `main` can return 0 or 1 as success or error
- Using pytest's `capsys` to test std out and error rather than mocking print

## Notes
I did a lot of this so we could test the cli itself, but did not yet write tests for it. One step at a time 🤷 

## Edit
Since the latest dojo, I've made the change to operationalize the tool as well i.e calling `image.deregister()`